### PR TITLE
Fixed the when index_locked=true,index=null error

### DIFF
--- a/src/main/java/com/codingchili/Controller/Website.java
+++ b/src/main/java/com/codingchili/Controller/Website.java
@@ -127,6 +127,10 @@ public class Website extends AbstractVerticle {
 
             if (iterator.hasNext()) {
                 MultiMap params = context.request().params();
+                if (Configuration.isIndexLocked()) {
+                	params.add(INDEX, Configuration.getDefaultIndex());
+                }
+                        
                 logger.info("Receiving uploaded file with request id " + params.get(UPLOAD_ID));
                 FileUpload upload = context.fileUploads().iterator().next();
 


### PR DESCRIPTION
When I set the index_locked=true in the configuration, in Web UI, the field default index set to disable,but after upload the file, the default_index in request is null, so I set the default_index value from the configuration file.